### PR TITLE
Update test-addrset.sh

### DIFF
--- a/ncat/test/test-addrset.sh
+++ b/ncat/test/test-addrset.sh
@@ -36,18 +36,21 @@ test_addrset() {
 # Takes as an argument a host specification with invalid syntax. The
 # test passes if addrset returns with a non-zero exit code.
 expect_fail() {
-	specs=$1
-	$ADDRSET $specs < /dev/null 2> /dev/null
-	ret=$?
-	TESTS=$(expr $TESTS + 1)
-	if [ "$ret" = "0" ]; then
-		echo "FAIL $ADDRSET $specs was expected to fail, but didn't."
-		TEST_FAIL=$(expr $TEST_FAIL + 1)
-	else
-		echo "PASS $specs"
-		TEST_PASS=$(expr $TEST_PASS + 1)
-	fi
+    specs="$1"
+    output="$($ADDRSET "$specs" 2> /dev/null)"
+    ret=$?
+
+    TESTS=$((TESTS + 1))
+
+    if [ "$ret" -eq 0 ]; then
+        echo "FAIL $ADDRSET $specs was expected to fail, but didn't."
+        TEST_FAIL=$((TEST_FAIL + 1))
+    else
+        echo "PASS $specs"
+        TEST_PASS=$((TEST_PASS + 1))
+    fi
 }
+
 
 # seq replacement for systems without seq.
 seq() {


### PR DESCRIPTION
1. The line `$ADDRSET $specs < /dev/null 2> /dev/null`  uses command substitution to capture the output and errors of the command. This can be improved by using "$($ADDRSET $specs < /dev/null 2> /dev/null)" to capture the output directly into a variable. 

2. The input redirection < /dev/null and error redirection 2> /dev/null might be unnecessary in some cases. If they are not needed, they can be removed for simplicity.